### PR TITLE
Use single quotes around -

### DIFF
--- a/lr.1
+++ b/lr.1
@@ -31,7 +31,7 @@ is an empty string, the current directory is used by default.
 The special
 .Ar path
 argument
-.Ic \&-
+.Sq \&-
 makes
 .Nm
 read file names from standard input,


### PR DESCRIPTION
This may be purely personal, but I think `.Sq` makes more sense here than `.Ic`, and I think it reads better on the screen. (`.Ar` would make the most sense, but it looks like a weird `=` sign!)