### PR TITLE
lr.1: fix mandoc lint warnings

### DIFF
--- a/lr.1
+++ b/lr.1
@@ -79,8 +79,11 @@ and
 .Ic total
 are computed on the fly.
 .It Fl F
-Output filenames and an indicator of their file type (one of
-.Sq Li */=>@| ) .
+Output filenames and an indicator of their file type
+.Po
+one of
+.Sq Li */=>@\&|
+.Pc .
 .It Fl G
 Colorize output to TTY.
 Use twice to force colorized output.
@@ -208,8 +211,11 @@ Symlink target
 .It Ic \&%n
 Number of hardlinks
 .It Ic \&%F
-File indicator type symbol (one of
-.Sq Li */=>@| )
+File indicator type symbol
+.Po
+one of
+.Sq Li */=>@\&|
+.Pc
 .It Ic \&%f
 File basename (everything after last
 .Li / )


### PR DESCRIPTION
- mandoc warns "STYLE: no blank before trailing delimiter:"
  so insert '\&' before last delimeter
- while here, replace parentheses with .Po / .Pc