### PR TITLE
More tweaks to the lrls wrapper script

### DIFF
--- a/contrib/lrls
+++ b/contrib/lrls
@@ -17,7 +17,7 @@ if [ -t 1 ]; then
     use_column=1
 fi
 
-while getopts :01ABC:DFGHLQPST:UWXde:f:lho:st:x opt; do
+while getopts :01ABC:DFGHLPQST:UWXde:f:hlo:qst:x opt; do
     case $opt in
     # If we're not entering directories:
     # - Avoid depth check so directory names aren't skipped entirely.

--- a/contrib/lrls
+++ b/contrib/lrls
@@ -5,9 +5,9 @@
 #
 #     # Clear any system-level aliases:
 #     unalias ls la ll 2>/dev/null
-#     alias ls='lslr -A'
-#     alias la='lslr'
-#     alias ll='lslr -lh'
+#     alias ls='lrls -A'
+#     alias la='lrls'
+#     alias ll='lrls -lh'
 
 use_strip=1
 check_depth=1

--- a/contrib/lrls
+++ b/contrib/lrls
@@ -8,6 +8,9 @@
 #     alias ls='lrls -A'
 #     alias la='lrls'
 #     alias ll='lrls -lh'
+#
+# Set the environment variable LR_GNU_COLORS=1 to override (some) of the output
+# colors to match the default GNU colors.
 
 use_strip=1
 check_depth=1
@@ -15,6 +18,10 @@ check_depth=1
 if [ -t 1 ]; then
     use_color=1
     use_column=1
+fi
+
+if [ -n "$use_color" -a -n "$LR_GNU_COLORS" ]; then
+    gnu_colors=1
 fi
 
 while getopts :01ABC:DFGHLPQST:UWXde:f:hlo:qst:x opt; do
@@ -41,6 +48,11 @@ lr -1 \
     ${use_color:+-GG} \
     ${use_strip:+-s} \
     ${check_depth:+-t '!type == d || depth > 0'} \
+    ${gnu_colors:+-t 'type == f && color 15 || print'} \
+    ${gnu_colors:+-t 'type == p && color 11 || print'} \
+    ${gnu_colors:+-t 'mode == "+x" && color 10 || print'} \
+    ${gnu_colors:+-t 'type == l && color 14 || print'} \
+    ${gnu_colors:+-t 'type == d && color 12 || print'} \
     "$@" | {
         if [ -n "$use_column" ]; then
             git column --mode=dense --pad=2


### PR DESCRIPTION
- Add the new `-q` option.
- Two bug fixes (to my previous addition).
- Two usability tweaks to match `ls` behavior a little more closely.
- One (optional) color override for curmudgeons that are overly accustomed to "traditional" colors.  :-P

Each of these changes is a separate commit, so I'm happy to replace this PR with separate PRs if you'd prefer not to bring them all in. Rationale for each change is in the commit message and/or a comment, but questions welcome!

The `ls`-replacement tweaks are starting to add up, so I've been using the below for remembering/testing edge-cases and expected output:
```
% mkdir foo
% touch -- foo/Foo bar .baz -Aqux

% lrls -AF
-Aqux  bar  foo/

% lrls -AF .baz
.baz

% lrls -AF -- -Aqux
-Aqux

% lrls -F foo/Foo bar
bar  foo/Foo

% lslr -dF foo
foo/
```